### PR TITLE
A few small tweaks

### DIFF
--- a/plugin/islime2.vim
+++ b/plugin/islime2.vim
@@ -27,7 +27,7 @@ vnoremap <leader>cc "ry:call <SID>iTermSendNext(@r)<CR>
 nnoremap <leader>cc vip"ry:call <SID>iTermSendNext(@r)<CR>
 
 " Send the whole file
-nnoremap <leader>cf 1<S-v><S-g>"ry:call <SID>iTermSendNext(@r)<CR>
+nnoremap <leader>cf :%y r<cr>:call <SID>iTermSendNext(@r)<CR>
 
 " Run script/deliver
 nnoremap <leader>fd :call <SID>iTermSendNext("./script/deliver")<CR>

--- a/plugin/islime2.vim
+++ b/plugin/islime2.vim
@@ -55,7 +55,7 @@ let s:current_file=expand("<sfile>")
 function! s:iTermSendNext(command)
   let l:run_command = fnamemodify(s:current_file, ":p:h:h") . "/scripts/run_command.scpt"
   let g:islime2_last_command = a:command
-  call system("osascript " . l:run_command . " " . s:shellesc(a:command))
+  call system("osascript " . l:run_command . " " . s:shellesc(substitute(a:command, '\n$', '', '')))
 endfunction
 
 function! s:shellesc(arg) abort

--- a/scripts/run_command.scpt
+++ b/scripts/run_command.scpt
@@ -1,11 +1,19 @@
 on runInNextPane(_command)
   tell application "iTerm"
-    tell current terminal
-      tell i term application "System Events" to keystroke "]" using command down
+    set isRunning to (it is running)
+    set myterm to (current terminal)
+    try
+      set tmp to myterm
+    on error
+      set myterm to (make new terminal)
+    end try
+    tell myterm
+      if not isRunning then
+        activate
+      end if
       tell current session
         write text _command
       end tell
-      tell i term application "System Events" to keystroke "[" using command down
     end tell
   end tell
 end runInNextPane


### PR DESCRIPTION
- do not jump to end of file after sending text to iTerm (by eliminating the key strokes in the OSA script)
- eliminate extra new line sent to iTerm when pressing <Leader>cc from VISUAL LINE mode
- do not change cursor position when sending whole file with <Leader>cf