### PR TITLE
A few small tweaks, reloaded

### DIFF
--- a/plugin/islime2.vim
+++ b/plugin/islime2.vim
@@ -56,7 +56,8 @@ function! s:iTermSendNext(command)
   let l:run_command = fnamemodify(s:current_file, ":p:h:h") . "/scripts/run_command.scpt"
   let g:islime2_last_command = a:command
   let l:mode = has('gui_running') ? 'gui' : 'terminal'
-  call system("osascript " . l:run_command . " " . s:shellesc(a:command) . " " . l:mode)
+  call system("osascript " . l:run_command . " " . s:shellesc(
+        \ substitute(a:command, '\n$', '', '')) . " " . l:mode)
 endfunction
 
 function! s:shellesc(arg) abort

--- a/plugin/islime2.vim
+++ b/plugin/islime2.vim
@@ -27,7 +27,7 @@ vnoremap <leader>cc "ry:call <SID>iTermSendNext(@r)<CR>
 nnoremap <leader>cc vip"ry:call <SID>iTermSendNext(@r)<CR>
 
 " Send the whole file
-nnoremap <leader>cf 1<S-v><S-g>"ry:call <SID>iTermSendNext(@r)<CR>
+nnoremap <leader>cf :%y r<cr>:call <SID>iTermSendNext(@r)<CR>
 
 " Run script/deliver
 nnoremap <leader>fd :call <SID>iTermSendNext("./script/deliver")<CR>

--- a/plugin/islime2.vim
+++ b/plugin/islime2.vim
@@ -55,7 +55,8 @@ let s:current_file=expand("<sfile>")
 function! s:iTermSendNext(command)
   let l:run_command = fnamemodify(s:current_file, ":p:h:h") . "/scripts/run_command.scpt"
   let g:islime2_last_command = a:command
-  call system("osascript " . l:run_command . " " . s:shellesc(a:command))
+  let l:mode = has('gui_running') ? 'gui' : 'terminal'
+  call system("osascript " . l:run_command . " " . s:shellesc(a:command) . " " . l:mode)
 endfunction
 
 function! s:shellesc(arg) abort

--- a/scripts/run_command.scpt
+++ b/scripts/run_command.scpt
@@ -1,16 +1,21 @@
-on runInNextPane(_command)
+on runInNextPane(_command, _mode)
   tell application "iTerm"
     tell current terminal
-      tell i term application "System Events" to keystroke "]" using command down
+      if _mode = "terminal" then
+        tell i term application "System Events" to keystroke "]" using command down
+      end if
       tell current session
         write text _command
       end tell
-      tell i term application "System Events" to keystroke "[" using command down
+      if _mode = "terminal" then
+        tell i term application "System Events" to keystroke "[" using command down
+      end if
     end tell
   end tell
 end runInNextPane
 
 on run argv
   set _command to item 1 of argv
-  runInNextPane(_command)
+  set _mode to item 2 of argv
+  runInNextPane(_command, _mode)
 end run


### PR DESCRIPTION
Redo of https://github.com/matschaffer/vim-islime2/pull/3:

- do not jump to end of file after sending text to iTerm (by eliminating the key strokes in the OSA script, for gVim only)
- eliminate extra new line sent to iTerm when pressing <Leader>cc from VISUAL LINE mode
- do not change cursor position when sending whole file with <Leader>cf