### PR TITLE
Use autoload and remove mappings

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,42 +20,58 @@ If you're using this on iTerm 2.9 or above (nightly as of 2015/09/17), you'll al
 let g:islime2_29_mode=1
 ```
 
-## Caveats
-
-At the moment rather than support all the possible testing methods I have `<leader>ft` try to run `script/test` against the current file and `<leader>fT` pass the current file as `path:line_number`. I'll include a contrib directory with various testing tools in the near future but for now a simple `script/test` for Rails would be:
-
-    #!/bin/sh
-    ruby -Itest "$@"
-
-Of course this wouldn't support focused unit testing. More on that to come soon.
-
-If you're using rspec, focused testing works just fine, like so:
-
-    #!/bin/sh
-    rspec "$@"
-
 ## Usage
 
 ### For any commands
 
 * `ISlime2 echo hi mom` - runs "echo hi mom"
-* `<leader>ff` - re-runs the last run command
-* `<leader>fp` - equivalent to hitting up then enter in the terminal
 
-### For testing
+## Recommended Mappings
 
-* `<leader>ft` - runs `script/test path/to/current/file`
-* `<leader>fT` - runs `script/test path/to/current/file:line_number`
+```vim
+let g:islime2_29_mode=1
 
-### For REPLs
+" Send current line
+nnoremap <silent> <Leader>i<CR> :ISlime2CurrentLine<CR>
 
-* `<leader>cc` - sends the current paragraph (using `vip`) or selection to the terminal
-* `<leader>cf` - sends the whole file to the terminal
+" Move to next line then send it
+nnoremap <silent> <Leader>ij :ISlime2NextLine<CR>
 
-### Other helpers
+" Move to previous line then send it
+nnoremap <silent> <Leader>ik :ISlime2PreviousLine<CR>
 
-* `<leader>fr` - runs `rake`
-* `<leader>fd` - runs `script/deliver` which I use to merge to master and deploy to staging
+" Send in/around text object - operation pending
+nnoremap <silent> <Leader>i :set opfunc=islime2#iTermSendOperator<CR>g@
+
+" Send visual selection
+vnoremap <silent> <Leader>i :<C-u>call islime2#iTermSendOperator(visualmode(), 1)<CR>
+```
+
+## More Example Mappings
+
+```vim
+" Send the whole file
+nnoremap <leader>cf :%y r<cr>:call islime2#iTermSendNext(@r)<CR>
+
+" Rerun the previous iSlime2 command
+nnoremap <leader>ff :call islime2#iTermRerun()<CR>
+
+" Send up and enter to re-run the previous command
+nnoremap <leader>fp :call islime2#iTermSendUpEnter()<CR>
+
+" Run script/deliver
+nnoremap <leader>fd :call islime2#iTermSendNext("./script/deliver")<CR>
+
+" Run rake
+nnoremap <leader>fr :call islime2#iTermSendNext("rake")<CR>
+
+" Run file as a test (assumes ./script/test)
+nnoremap <leader>ft :call islime2#iTermRunTest(expand("%"))<CR>
+remap <leader>ft :call islime2#iTermRunTest(expand("%"))<CR>")
+
+" Run focused unit test (assumes ./script/test understands file:line notation)
+nnoremap <leader>fT :call islime2#iTermRunTest(expand("%") . ":" . line("."))<CR>
+```
 
 ## Contributions
 

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ SLIME-like support for running vim with iTerm2
 
 ## What is it?
 
-For the video-inclined [watch it here](http://www.youtube.com/watch?v=33Hz6OguYT8).
+<img src='https://raw.githubusercontent.com/ddrscott/vim-islime2/gh-pages/demo.gif'/>
 
 It lets you send commands from Vim to an iTerm2 session. This is handy if you need to run a command repeatedly (like a test) and want to see the output. This is especially nice in text-mode Vim, but it works fine from MacVim's GUI too.
 

--- a/autoload/islime2.vim
+++ b/autoload/islime2.vim
@@ -1,0 +1,60 @@
+" iSlime2.vim - SLIME-like support for running Vim with iTerm2
+" Maintainer:   Mat Schaffer <http://matschaffer.com>
+" Version:      0.1
+
+function! islime2#iTermRerun()
+  if exists("g:islime2_last_command")
+    call islime2#iTermSendNext(g:islime2_last_command)
+  else
+    echoerr "No previous command. Try running a test first (with <leader>ft). Or you can store a command with `ISlime2 my command`"
+  endif
+endfunction
+
+function! islime2#iTermSendUpEnter()
+  call islime2#iTermSendNext("OA")
+endfunction
+
+function! islime2#iTermRunTest(file)
+  if filereadable("script/test")
+    call islime2#iTermSendNext("script/test " . a:file)
+  else
+    echoerr "Couldn't execute " . getcwd() . "/script/test, please create test runner script."
+  endif
+endfunction
+
+let s:current_file=expand("<sfile>")
+
+" Sends the passed command to the next iTerm2 panel using Cmd+]
+function! islime2#iTermSendNext(command)
+  let l:script_name = (exists('g:islime2_29_mode') && g:islime2_29_mode == 1) ? 'run_command29' : 'run_command'
+
+  let l:run_command = fnamemodify(s:current_file, ":p:h:h") . "/scripts/" . l:script_name . ".scpt"
+
+  let g:islime2_last_command = a:command
+  let l:mode = has('gui_running') ? 'gui' : 'terminal'
+  call system("osascript " . l:run_command . " " . l:mode . " " . islime2#shellesc(
+        \ substitute(a:command, '\n$', '', '')))
+endfunction
+
+function! islime2#shellesc(arg) abort
+  return '"'.escape(a:arg, '"').'"'
+endfunction
+
+function! islime2#iTermSendOperator(type, ...) abort
+  let sel_save = &selection
+  let &selection = "inclusive"
+  let z=@z
+  try
+    if a:0  " Invoked from Visual mode, use gv command.
+      silent exe "normal! gv\"zy"
+    elseif a:type == 'line'
+      silent exe "normal! '[V']\"zy"
+    else
+      silent exe "normal! `[v`]\"zy"
+    endif
+    call islime2#iTermSendNext(@z)
+  finally
+    let &selection = sel_save
+    let @z=z
+  endtry
+endfunction

--- a/plugin/islime2.vim
+++ b/plugin/islime2.vim
@@ -1,68 +1,9 @@
-" iSlime2.vim - SLIME-like support for running Vim with iTerm2
-" Maintainer:   Mat Schaffer <http://matschaffer.com>
-" Version:      0.1
+command! -nargs=+ ISlime2 :call islime2#iTermSendNext("<args>")
 
-" Allows running arbitrary command with :ISlime2
-command! -nargs=+ ISlime2 :call <SID>iTermSendNext("<args>")
+command! ISlime2CurrentLine :call islime2#iTermSendNext(getline('.'))
 
-" Rerun the previous iSlime2 command
-nnoremap <leader>ff :call <SID>iTermRerun()<CR>
-function! s:iTermRerun()
-  if exists("g:islime2_last_command")
-    call s:iTermSendNext(g:islime2_last_command)
-  else
-    echoerr "No previous command. Try running a test first (with <leader>ft). Or you can store a command with `ISlime2 my command`"
-  endif
-endfunction
+" Literally `j` then ISlime2CurrentLine
+command! ISlime2NextLine :execute "norm j:ISlime2CurrentLine<CR>"
 
-" Send up and enter to re-run the previous command
-nnoremap <leader>fp :call <SID>iTermSendUpEnter()<CR>
-function! s:iTermSendUpEnter()
-  call s:iTermSendNext("OA")
-endfunction
-
-" Send the current visual selection or paragraph
-inoremap <leader>cc <Esc>vip"ry:call <SID>iTermSendNext(@r)<CR>
-vnoremap <leader>cc "ry:call <SID>iTermSendNext(@r)<CR>
-nnoremap <leader>cc vip"ry:call <SID>iTermSendNext(@r)<CR>
-
-" Send the whole file
-nnoremap <leader>cf :%y r<cr>:call <SID>iTermSendNext(@r)<CR>
-
-" Run script/deliver
-nnoremap <leader>fd :call <SID>iTermSendNext("./script/deliver")<CR>
-
-" Run rake
-nnoremap <leader>fr :call <SID>iTermSendNext("rake")<CR>
-
-" Run file as a test (assumes ./script/test)
-nnoremap <leader>ft :call <SID>iTermRunTest(expand("%"))<CR>
-
-" Run focused unit test (assumes ./script/test understands file:line notation)
-nnoremap <leader>fT :call <SID>iTermRunTest(expand("%") . ":" . line("."))<CR>
-
-function! s:iTermRunTest(file)
-  if filereadable("script/test")
-    call s:iTermSendNext("script/test " . a:file)
-  else
-    echoerr "Couldn't execute " . getcwd() . "/script/test, please create test runner script."
-  endif
-endfunction
-
-let s:current_file=expand("<sfile>")
-
-" Sends the passed command to the next iTerm2 panel using Cmd+]
-function! s:iTermSendNext(command)
-  let l:script_name = (exists('g:islime2_29_mode') && g:islime2_29_mode == 1) ? 'run_command29' : 'run_command'
-
-  let l:run_command = fnamemodify(s:current_file, ":p:h:h") . "/scripts/" . l:script_name . ".scpt"
-
-  let g:islime2_last_command = a:command
-  let l:mode = has('gui_running') ? 'gui' : 'terminal'
-  call system("osascript " . l:run_command . " " . l:mode . " " . s:shellesc(
-        \ substitute(a:command, '\n$', '', '')))
-endfunction
-
-function! s:shellesc(arg) abort
-  return '"'.escape(a:arg, '"').'"'
-endfunction
+" Literally `k` then ISlime2CurrentLine
+command! ISlime2PreviousLine :execute "norm k:ISlime2CurrentLine<CR>"


### PR DESCRIPTION
- The original mappings overwrote a lot of mines, so I moved them to the README for others to see who the could use the functions/commands.
- created `islime2#iTermSendOperator` which is much more flexible than the original visual mapping
- moved from `plugin` to `autoload` as a best practice.

I'm not expecting this to be merged without a few more tweaks, but figured you might be interested in the operator pending option.